### PR TITLE
fix build failure in Apple M1

### DIFF
--- a/src/x86_cpuid.c
+++ b/src/x86_cpuid.c
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#if defined(__i386__) || defined(__x86_64__)
+
 #if defined(_MSC_VER)
 # include <intrin.h>
 #endif
@@ -105,3 +107,5 @@ bool feslite_sse2_available()
 
     return 0;
 }
+
+#endif


### PR DESCRIPTION
Running `make` in Apple M1 produces the following build failure. This is due to the checking the availability of x86 vector instructions in `x86_cpuid.c`

```
[ 25%] Building C object src/CMakeFiles/feslite.dir/naive_eval.c.o
[ 25%] Building C object src/CMakeFiles/feslite.dir/generic_eval32.c.o
[ 25%] Building C object src/CMakeFiles/feslite.dir/generic_minimal.c.o
[ 25%] Building C object src/CMakeFiles/feslite.dir/feslite.c.o
[ 37%] Building C object src/CMakeFiles/feslite.dir/generic_1x32.c.o
[ 37%] Building C object src/CMakeFiles/feslite.dir/generic_2x16.c.o
[ 50%] Building C object src/CMakeFiles/feslite.dir/generic_4x16.c.o
[ 50%] Building C object src/CMakeFiles/feslite.dir/generic_2x32.c.o
[ 56%] Building C object src/CMakeFiles/feslite.dir/x86_cpuid.c.o
/Users/rusydi/CLionProjects/libfes-lite/src/x86_cpuid.c:18:25: error: invalid output constraint '+b' in asm
    __asm__ ( "cpuid" : "+b" (ebx),
                        ^
1 error generated.
make[2]: *** [src/CMakeFiles/feslite.dir/x86_cpuid.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [src/CMakeFiles/feslite.dir/all] Error 2
make: *** [all] Error 2
```